### PR TITLE
Filter Dependencies from Test Coverage

### DIFF
--- a/Sources/SDGSwift/SwiftCompiler.swift
+++ b/Sources/SDGSwift/SwiftCompiler.swift
@@ -288,6 +288,7 @@ public enum SwiftCompiler: VersionedExternalProcess {
               let url = URL(fileURLWithPath: fileName)
 
               if ¬ignoredDirectories.contains(where: { url.is(in: $0) }),
+                ¬url.pathComponents.contains("DerivedData"),
                 url.pathExtension == "swift",
                 url.lastPathComponent ≠ "LinuxMain.swift"
               {


### PR DESCRIPTION
Filtering was already being done for SwiftPM, and for generated Xcode projects, but Xcode’s package support was missed.